### PR TITLE
Check for `frc-sdk` header

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,27 +1,39 @@
 name: goreleaser
 
 on:
-  pull_request:
   push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: "^1.21"
+          go-version: 1.21
+      
+      - name: Format
+        working-directory: friendly-captcha-sdk-testserver
+        run: if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then exit 1; fi
+  
+      - name: vet
+        working-directory: friendly-captcha-sdk-testserver
+        run: if [ "$(go vet ./... | wc -l)" -gt 0 ]; then exit 1; fi
+    
       - name: GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
           workdir: friendly-captcha-sdk-testserver
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/friendly-captcha-sdk-testserver/goreleaser.yml
+++ b/friendly-captcha-sdk-testserver/goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 project_name: friendly-captcha-sdk-testserver
 builds:
   - binary: friendly-captcha-sdk-testserver


### PR DESCRIPTION
This adds a check that the `frc-sdk` header was set. Some SDKs set the `x-frc-sdk` - those should be updated.