### PR TITLE
Update risk intelligence response

### DIFF
--- a/friendly-captcha-sdk-testserver/fixtures/captcha_siteverify_test_cases.json
+++ b/friendly-captcha-sdk-testserver/fixtures/captcha_siteverify_test_cases.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "tests": [
     {
       "name": "success",
@@ -417,23 +417,99 @@
             "timestamp": "2023-08-04T13:01:25Z",
             "origin": "https://example.com"
           },
-          "risk_intelligence": {
-            "risk_scores": {
-              "overall": 3,
-              "network": 3,
-              "browser": 2
+          "risk_scores": {
+            "overall": 2,
+            "network": 1,
+            "browser": 1
+          },
+          "network": {
+            "ip": "88.64.123.45",
+            "as": {
+              "number": 3209,
+              "name": "VODANET",
+              "company": "Vodafone GmbH",
+              "description": "Provides mobile and fixed broadband and telecommunication services to consumers and businesses.",
+              "domain": "vodafone.de",
+              "country": "DE",
+              "rir": "RIPE",
+              "route": "88.64.0.0/12",
+              "type": "isp"
             },
-            "client": {
-              "header_user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
-              "browser": {
-                "id": "chrome",
-                "name": "Chrome",
-                "version": "91.0.4472.124",
-                "release_date": "2021-06-24"
+            "geolocation": {
+              "country": {
+                "iso2": "DE",
+                "iso3": "DEU",
+                "name": "Germany",
+                "name_native": "Deutschland",
+                "region": "Europe",
+                "subregion": "Western Europe",
+                "currency": "EUR",
+                "currency_name": "Euro",
+                "phone_code": "49",
+                "capital": "Berlin"
+              },
+              "city": "Eschborn",
+              "state": "Hessen"
+            },
+            "abuse_contact": {
+              "address": "Vodafone GmbH, Campus Eschborn, Duesseldorfer Strasse 15, D-65760 Eschborn, Germany",
+              "name": "Vodafone Germany IP Core Backbone",
+              "email": "abuse.de@vodafone.com",
+              "phone": "+49 6196 52352105"
+            },
+            "anonymization": {
+              "vpn_score": 2,
+              "proxy_score": 1,
+              "tor": false,
+              "icloud_private_relay": false
+            }
+          },
+          "client": {
+            "header_user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:146.0) Gecko/20100101 Firefox/146.0",
+            "time_zone": {
+              "name": "Europe/Berlin",
+              "country_iso2": "DE"
+            },
+            "browser": {
+              "id": "firefox",
+              "name": "Firefox",
+              "version": "146.0",
+              "release_date": "2026-01-28"
+            },
+            "browser_engine": {
+              "id": "gecko",
+              "name": "Gecko",
+              "version": "146.0"
+            },
+            "device": {
+              "type": "desktop",
+              "brand": "",
+              "model": ""
+            },
+            "os": {
+              "id": "windows",
+              "name": "Windows",
+              "version": "10"
+            },
+            "tls_signature": {
+              "ja3": "d87a30a5782a73a83c1544bb06332780",
+              "ja3n": "28ecc2d2875b345cecbb632b12d8c1e0",
+              "ja4": "t13d1516h2_8daaf6152771_02713d6af862"
+            },
+            "automation": {
+              "automation_tool": {
+                "detected": false,
+                "id": "",
+                "name": "",
+                "type": ""
+              },
+              "known_bot": {
+                "detected": false,
+                "id": "",
+                "name": "",
+                "type": "",
+                "url": ""
               }
-            },
-            "network": {
-              "ip": "127.0.0.1"
             }
           }
         }

--- a/friendly-captcha-sdk-testserver/fixtures/captcha_siteverify_test_cases.json
+++ b/friendly-captcha-sdk-testserver/fixtures/captcha_siteverify_test_cases.json
@@ -426,8 +426,14 @@
             "client": {
               "header_user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
               "browser": {
-                "id": "chrome"
+                "id": "chrome",
+                "name": "Chrome",
+                "version": "91.0.4472.124",
+                "release_date": "2021-06-24"
               }
+            },
+            "network": {
+              "ip": "127.0.0.1"
             }
           }
         }
@@ -460,6 +466,9 @@
             "client": {
               "header_user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
               "browser": null
+            },
+            "network": {
+              "ip": "127.0.0.1"
             }
           }
         }

--- a/friendly-captcha-sdk-testserver/fixtures/risk_intelligence_retrieve_test_cases.json
+++ b/friendly-captcha-sdk-testserver/fixtures/risk_intelligence_retrieve_test_cases.json
@@ -16,8 +16,14 @@
             "client": {
               "header_user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
               "browser": {
-                "id": "chrome"
+                "id": "chrome",
+                "name": "Chrome",
+                "version": "91.0.4472.124",
+                "release_date": "2021-06-24"
               }
+            },
+            "network": {
+              "ip": "127.0.0.1"
             }
           },
           "details": {
@@ -48,6 +54,9 @@
             "client": {
               "header_user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
               "browser": null
+            },
+            "network": {
+              "ip": "127.0.0.1"
             }
           },
           "details": {

--- a/friendly-captcha-sdk-testserver/fixtures/risk_intelligence_retrieve_test_cases.json
+++ b/friendly-captcha-sdk-testserver/fixtures/risk_intelligence_retrieve_test_cases.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": 2,
   "tests": [
     {
       "name": "success",
@@ -9,21 +9,99 @@
         "data": {
           "risk_intelligence": {
             "risk_scores": {
-              "overall": 3,
-              "network": 3,
-              "browser": 2
-            },
-            "client": {
-              "header_user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
-              "browser": {
-                "id": "chrome",
-                "name": "Chrome",
-                "version": "91.0.4472.124",
-                "release_date": "2021-06-24"
-              }
+              "overall": 2,
+              "network": 1,
+              "browser": 1
             },
             "network": {
-              "ip": "127.0.0.1"
+              "ip": "88.64.123.45",
+              "as": {
+                "number": 3209,
+                "name": "VODANET",
+                "company": "Vodafone GmbH",
+                "description": "Provides mobile and fixed broadband and telecommunication services to consumers and businesses.",
+                "domain": "vodafone.de",
+                "country": "DE",
+                "rir": "RIPE",
+                "route": "88.64.0.0/12",
+                "type": "isp"
+              },
+              "geolocation": {
+                "country": {
+                  "iso2": "DE",
+                  "iso3": "DEU",
+                  "name": "Germany",
+                  "name_native": "Deutschland",
+                  "region": "Europe",
+                  "subregion": "Western Europe",
+                  "currency": "EUR",
+                  "currency_name": "Euro",
+                  "phone_code": "49",
+                  "capital": "Berlin"
+                },
+                "city": "Eschborn",
+                "state": "Hessen"
+              },
+              "abuse_contact": {
+                "address": "Vodafone GmbH, Campus Eschborn, Duesseldorfer Strasse 15, D-65760 Eschborn, Germany",
+                "name": "Vodafone Germany IP Core Backbone",
+                "email": "abuse.de@vodafone.com",
+                "phone": "+49 6196 52352105"
+              },
+              "anonymization": {
+                "vpn_score": 2,
+                "proxy_score": 1,
+                "tor": false,
+                "icloud_private_relay": false
+              }
+            },
+            "client": {
+              "header_user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:146.0) Gecko/20100101 Firefox/146.0",
+              "time_zone": {
+                "name": "Europe/Berlin",
+                "country_iso2": "DE"
+              },
+              "browser": {
+                "id": "firefox",
+                "name": "Firefox",
+                "version": "146.0",
+                "release_date": "2026-01-28"
+              },
+              "browser_engine": {
+                "id": "gecko",
+                "name": "Gecko",
+                "version": "146.0"
+              },
+              "device": {
+                "type": "desktop",
+                "brand": "",
+                "model": ""
+              },
+              "os": {
+                "id": "windows",
+                "name": "Windows",
+                "version": "10"
+              },
+              "tls_signature": {
+                "ja3": "d87a30a5782a73a83c1544bb06332780",
+                "ja3n": "28ecc2d2875b345cecbb632b12d8c1e0",
+                "ja4": "t13d1516h2_8daaf6152771_02713d6af862"
+              },
+              "automation": {
+                "automation_tool": {
+                  "detected": false,
+                  "id": "",
+                  "name": "",
+                  "type": ""
+                },
+                "known_bot": {
+                  "detected": false,
+                  "id": "",
+                  "name": "",
+                  "type": "",
+                  "url": ""
+                }
+              }
             }
           },
           "details": {

--- a/friendly-captcha-sdk-testserver/main.go
+++ b/friendly-captcha-sdk-testserver/main.go
@@ -24,8 +24,8 @@ const (
 	defaultCaptchaSiteverifyTestsJSONEndpoint        = "/api/v1/captcha/siteverifyTests"
 	defaultRiskIntelligenceRetrieveTestsJSONEndpoint = "/api/v1/riskIntelligence/retrieveTests"
 
-	expectedCaptchaSiteverifyTestsFileVersion        = 2
-	expectedRiskIntelligenceRetrieveTestsFileVersion = 1
+	expectedCaptchaSiteverifyTestsFileVersion        = 3
+	expectedRiskIntelligenceRetrieveTestsFileVersion = 2
 )
 
 var CLI struct {


### PR DESCRIPTION
This PR changes the fixtures to have one full risk intelligence response (taken from the docs example) and fixes the other to be a minimal one with all non-nullable fields present.